### PR TITLE
Fix tests, fix en->zh translation, add trans-see support

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,6 +107,8 @@ module.exports = function (moduleOptions) {
         search = '|' + toLang + '|';
       } else if (fromLang === 'zh') {
         search = '*' + toLangAsWord(fromLang, toLang) + '\uff1a';
+      } else if (fromLang === 'en' && toLang === 'zh') {
+        search = toLangAsWord(fromLang, toLang) + ':\n*: Mandarin: ';
       } else {
         search = toLangAsWord(fromLang, toLang) + ': ';
       }

--- a/index.js
+++ b/index.js
@@ -43,12 +43,28 @@ module.exports = function (moduleOptions) {
           '.wiktionary.org/w/api.php?format=json&action=query&rvprop=content&prop=revisions&redirects=1&titles=' +
           encodeURIComponent(word)
       }
-      getWiktionaryResponse(options, fromLang, toLang, done, function (description) {
+      getWiktionaryResponse(options, fromLang, toLang, done, function (description, transSee) {
         if (description === 'no hits' && word.toLowerCase() !== word) {
           // retry with lowercase search word
           options.url = 'https://' + fromLang +
             '.wiktionary.org/w/api.php?format=json&action=query&rvprop=content&prop=revisions&redirects=1&titles=' +
             encodeURIComponent(word.toLowerCase());
+          getWiktionaryResponse(options, fromLang, toLang, done, function (description, transSee) {
+            if (description === 'no hits') {
+              done(null);
+            } else if (description === 'trans-see' && transSee) {
+              options.url = 'https://' + fromLang +
+                '.wiktionary.org/w/api.php?format=json&action=query&rvprop=content&prop=revisions&redirects=1&titles=' + transSee;
+              getWiktionaryResponse(options, fromLang, toLang, done, function (description) {
+                if (description === 'no hits') {
+                  done(null);
+                }
+              });
+            }
+          });
+        } else if (description === 'trans-see' && transSee) {
+          options.url = 'https://' + fromLang +
+            '.wiktionary.org/w/api.php?format=json&action=query&rvprop=content&prop=revisions&redirects=1&titles=' + transSee;
           getWiktionaryResponse(options, fromLang, toLang, done, function (description) {
             if (description === 'no hits') {
               done(null);
@@ -66,7 +82,7 @@ module.exports = function (moduleOptions) {
         if (pages[-1] && typeof pages[-1].missing !== 'undefined' && pages[-1].missing === '') {
           return retryFunction('no hits');
         }
-        clearWiktionaryContent(pages, fromLang, toLang, done);
+        clearWiktionaryContent(pages, fromLang, toLang, done, retryFunction);
       } else {
         logger.error('error in getting word from Wiktionary', error);
         done(null, error);
@@ -74,7 +90,7 @@ module.exports = function (moduleOptions) {
     });
   }
 
-  function clearWiktionaryContent(pages, fromLang, toLang, done) {
+  function clearWiktionaryContent(pages, fromLang, toLang, done, retryFunction) {
     for (var pageId in pages) {
       if (!pages[pageId].revisions) {
         continue;
@@ -159,12 +175,22 @@ module.exports = function (moduleOptions) {
           cleanedTerms.add(term);
         }
       }
+
+      if (cleanedTerms && cleanedTerms.size) {
+        done(Array.from(cleanedTerms));
+      } else {
+        // search for trans-see if translation exists for alternate word
+        search = '{{trans-see|';
+        texts = rawAnswer.split(search);
+        if (texts.length > 1) {
+          var transSee = texts[1].split('}}')[0];
+          retryFunction('trans-see', transSee);
+        } else {
+          done(null);
+        }
+      }
+
       break;
-    }
-    if (cleanedTerms && cleanedTerms.size) {
-      done(Array.from(cleanedTerms));
-    } else {
-      done(null);
     }
   }
 

--- a/test/wiktionary.js
+++ b/test/wiktionary.js
@@ -230,4 +230,14 @@ describe('Wiktionary tests', function () {
       done();
     });
   });
+
+  it('should get Chinese terms for "market" (en)', function (done) {
+    wiktionary.getDefinition('market', 'en', 'zh', function (terms, err) {
+      terms.should.have.length(3);
+      terms[0].should.equal('市場');
+      terms[1].should.equal('市场');
+      terms[2].should.equal('巴扎');
+      done();
+    });
+  });
 });

--- a/test/wiktionary.js
+++ b/test/wiktionary.js
@@ -32,39 +32,44 @@ describe('Wiktionary tests', function () {
 
   it('should get Finnish terms for "harbour" (en)', function (done) {
     wiktionary.getDefinition('harbour', 'en', 'fi', function (terms, err) {
-      terms.should.have.length(5);
+      terms.should.have.length(6);
       terms[0].should.equal('turvapaikka');
       terms[1].should.equal('turvasatama');
       terms[2].should.equal('satama');
       terms[3].should.equal('suojella');
-      terms[4].should.equal('tarjota suojapaikka');
+      terms[4].should.equal('tarjota suojapaikka / antaa suojapaikka');
+      terms[5].should.equal('hautoa mielessään');
       done();
     });
   });
 
   it('should get Finnish terms for "Harbour" (en)', function (done) {
     wiktionary.getDefinition('Harbour', 'en', 'fi', function (terms, err) {
-      terms.should.have.length(5);
+      terms.should.have.length(6);
       terms[0].should.equal('turvapaikka');
       terms[1].should.equal('turvasatama');
       terms[2].should.equal('satama');
       terms[3].should.equal('suojella');
-      terms[4].should.equal('tarjota suojapaikka');
+      terms[4].should.equal('tarjota suojapaikka / antaa suojapaikka');
+      terms[5].should.equal('hautoa mielessään');
       done();
     });
   });
 
   it('should get Finnish terms for "harbor" (en)', function (done) {
     wiktionary.getDefinition('harbor', 'en', 'fi', function (terms, err) {
-      terms.should.have.length(3);
-      terms[0].should.equal('suojella');
-      terms[1].should.equal('antaa suojapaikka');
-      terms[2].should.equal('hautoa mielessään');
+      terms.should.have.length(6);
+      terms[0].should.equal('turvapaikka');
+      terms[1].should.equal('turvasatama');
+      terms[2].should.equal('satama');
+      terms[3].should.equal('suojella');
+      terms[4].should.equal('tarjota suojapaikka / antaa suojapaikka');
+      terms[5].should.equal('hautoa mielessään');
       done();
     });
   });
 
-  it('should get a Finnish terms for "breach" (en)', function (done) {
+  it('should get Finnish terms for "breach" (en)', function (done) {
     wiktionary.getDefinition('breach', 'en', 'fi', function (terms, err) {
       terms.should.have.length(11);
       terms[0].should.equal('murros');
@@ -74,9 +79,11 @@ describe('Wiktionary tests', function () {
     });
   });
 
-  it('should get no Italian terms for "harbor" (en)', function (done) {
+  it('should get Italian terms for "harbor" (en)', function (done) {
     wiktionary.getDefinition('harbor', 'en', 'it', function (terms, err) {
-      should.equal(terms, null);
+      terms.should.have.length(2);
+      terms[0].should.equal('porto');
+      terms[1].should.equal('rifugiare');
       done();
     });
   });


### PR DESCRIPTION
Some tests were broken apparently because of translation changes/additions.

Also, at least english has added a trans-see property, if two words have the same meaning. Ex. "harbour" will not give any translations, but instead a trans-see property pointing to "harbor".

Also, english to chinese translation was broken because formatting had changed. This should now be fixed. Added a test as well.
